### PR TITLE
Correção no texto

### DIFF
--- a/comunicacao/seguranca/index.html
+++ b/comunicacao/seguranca/index.html
@@ -394,7 +394,7 @@
 <p>Toda a comunicação entre os controladores e a central é criptografada. Para isso são usados dois pares de chaves assimétricas por controlador. Um par na central e outro no controlador.</p>
 <p>Cada mensagem é criptografada com uma chave simétrica que é criptografada pela chave privada assimétrica. </p>
 <p>As chaves assimétricas são geradas automaticamente no cadastro do controlador na central. Cada controlador deve conhecer sua chave privada e a chave pública da central. As chaves simétricas devem ser geradas a cada nova mensagem trafegada.</p>
-<p>Dessa forma, toda a mensagem recebida no controlador deve ser descriptografada com a chave simétrica, após essa ser descriptografada pela chave privada assimétrica. O mesmo acontece no sentido contrário, ou seja, quando uma mensagem é recebida no controlador.</p>
+<p>Dessa forma, toda a mensagem recebida no controlador deve ser descriptografada com a chave simétrica, após essa ser descriptografada pela chave privada assimétrica. O mesmo acontece no sentido contrário, ou seja, quando uma mensagem é recebida na central.</p>
 <p>O esquema de segurança adotado pela central garante:</p>
 <h3 id="confiabilidade">Confiabilidade</h3>
 <p>Todas as informações são trafegadas criptografadas.</p>


### PR DESCRIPTION
Correção no texto sobre comunicação.
de:
Dessa forma, toda a mensagem recebida no controlador deve ser descriptografada com a chave simétrica, após essa ser descriptografada pela chave privada assimétrica. O mesmo acontece no sentido contrário, ou seja, quando uma mensagem é recebida no controlador.
para:
Dessa forma, toda a mensagem recebida no controlador deve ser descriptografada com a chave simétrica, após essa ser descriptografada pela chave privada assimétrica. O mesmo acontece no sentido contrário, ou seja, quando uma mensagem é recebida na central.